### PR TITLE
Fix of build warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     debug!("Started with following config {:?}", config);
 
     let user_encoded = config.user.map(|u| u.encoded());
-    let mut servers: Box<Future<Item=(), Error=std::io::Error>+Send> = Box::new(future::ok(()));
+    let mut servers: Box<dyn Future<Item=(), Error=std::io::Error>+Send> = Box::new(future::ok(()));
     for t in config.tunnels {
         debug!("Staring tunnel {}:{:?} on ", config.local_addr,t);
         let server = run_tunnel(

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -15,7 +15,7 @@ pub fn run_tunnel(
     tunnel: Tunnel,
     proxy: Option<Proxy>,
     user: Option<String>
-) -> Box<Future<Item = (), Error = ::std::io::Error>+Send> {
+) -> Box<dyn Future<Item = (), Error = ::std::io::Error>+Send> {
     // Bind the server's socket
     let addr = SocketAddr::new(local_addr, tunnel.local_port);
     let tcp = match TcpListener::bind(&addr) {

--- a/src/proxy/stream.rs
+++ b/src/proxy/stream.rs
@@ -95,7 +95,7 @@ impl Future for ConnectResponse {
 impl ProxyTcpStream {
     pub fn connect(addr: Tunnel, proxy: Option<&Proxy>, user: Option<String>) -> IoFuture<Self> {
         let addr2 = addr.clone();
-        let socket: Box<Future<Item=_, Error=IoError>+Send> = match proxy {
+        let socket: Box<dyn Future<Item=_, Error=IoError>+Send> = match proxy {
             None => {
                 debug!(
                     "Connecting directly to {}:{}",


### PR DESCRIPTION
Trivial fix of build warnings:
```
   Compiling ptunnel v0.2.0 (/home/jkalina/Fedora/ptunnel-rust/ptunnel-rust)
warning: trait objects without an explicit `dyn` are deprecated
  --> src/proxy/stream.rs:98:25
   |
98 |         let socket: Box<Future<Item=_, Error=IoError>+Send> = match proxy {
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item=_, Error=IoError>+Send`

warning: trait objects without an explicit `dyn` are deprecated
  --> src/proxy/mod.rs:18:10
   |
18 | ) -> Box<Future<Item = (), Error = ::std::io::Error>+Send> {
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = (), Error = ::std::io::Error>+Send`

warning: trait objects without an explicit `dyn` are deprecated
  --> src/main.rs:39:26
   |
39 |     let mut servers: Box<Future<Item=(), Error=std::io::Error>+Send> = Box::new(future::ok(()));
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item=(), Error=std::io::Error>+Send`

    Finished dev [unoptimized + debuginfo] target(s) in 2m 20s
```